### PR TITLE
Restores servingCount when recreating an Order from the Cart; skips P…

### DIFF
--- a/src/components/OrderIllustration.client.jsx
+++ b/src/components/OrderIllustration.client.jsx
@@ -5,13 +5,15 @@ import fourPeople from "../assets/four-people.svg";
 import smallPlate from "../assets/small-plate.svg";
 import largePlate from "../assets/large-plate.svg";
 import { TRADITIONAL_PLAN_NAME } from "../lib/const";
+import { useEffect } from "react";
 
 export default function OrderIllustration(props){
 
     const {activeScheme, servingCount, planPrice} = props;
 
     const setPeople = (servingCount) => {
-        switch(servingCount) {
+        const servingCountStr = String(servingCount);
+        switch(servingCountStr) {
             case '2':
             return 'Two People';
             case '3':

--- a/src/components/OrderSection.client.jsx
+++ b/src/components/OrderSection.client.jsx
@@ -52,6 +52,7 @@ export function OrderSection(props) {
     const [isGiftCardRemoved, setIsGiftCardRemoved] = useState(false);
     const [isPromtingEmptyCart, setIsPromptingEmptyCart] = useState(false);
     const [returnToPayment, setReturnToPayment] = useState(false);
+    const [planAlreadySelected, setIsPlanAlreadySelected] = useState(false);
 
     const [isAddingExtraItems, setIsAddingExtraItems] = useState(false)
     const [selectedSmallItems, setSelectedSmallItems] = useState([])
@@ -818,7 +819,7 @@ export function OrderSection(props) {
         setCurrentStep(1);
     }
 
-    const { zipcodeArr, entreeProducts, greensProducts, addonProducts, customerAlreadyOrdered, latestMenu } = props;
+    const { zipcodeArr, entreeProducts, greensProducts, addonProducts, customerAlreadyOrdered, latestMenu, traditionalPlanItem, flexiblePlanItem } = props;
     const zipcodeCheck = zipcodeArr.find(e => e.includes(zipcode));
 
     const setupCardsAndCollections = () => {
@@ -892,6 +893,32 @@ export function OrderSection(props) {
         const existingSmallItems = [];
         const existingSmallItemsExtra = [];
         const existingAddonItems = [];
+
+        // get existing PersonCount
+        cartLines.map(line => {
+            traditionalPlanItem.variants.edges.forEach(variant => {
+                if (line.merchandise.id === variant.node.id) {
+                    const {sku} = variant.node;
+                    const newServingCount = parseInt(sku.split("-")[1]); 
+                    setServingCount(newServingCount);
+                    setActiveScheme(TRADITIONAL_PLAN_NAME);
+                    setIsPlanAlreadySelected(true);
+                }
+            });
+
+            if (servingCount < 1) {
+                flexiblePlanItem.variants.edges.forEach(variant => {
+                    if (line.merchandise.id === variant.node.id) {
+                        const {sku} = variant.node;
+                        const newServingCount = parseInt(sku.split("-")[1]); 
+                        setServingCount(newServingCount);
+                        setActiveScheme(FLEXIBLE_PLAN_NAME);
+                        setIsPlanAlreadySelected(true);
+                    }
+                });
+            }
+            
+        });
 
         entreeProducts.map(entree => {
             // map cart items to pre-selected choices      
@@ -1009,6 +1036,9 @@ export function OrderSection(props) {
 
     const determineCurrentStep = () => {
         let newCurrentStep = 1;
+
+        if (planAlreadySelected)
+            newCurrentStep = 2;
 
         if (selectedAddonItems.length > 0)
             newCurrentStep = 4;

--- a/src/helpers/queries.js
+++ b/src/helpers/queries.js
@@ -304,6 +304,7 @@ export const GET_TRADITIONAL_PLAN_ITEM = gql`
         edges {
           node {
             id
+            sku
             price {
               amount
             }
@@ -321,6 +322,7 @@ export const GET_FLEXIBLE_PLAN_ITEM = gql`
         edges {
           node {
             id
+            sku
             price {
               amount
             }


### PR DESCRIPTION
When a Classic or Flex plan is in the Cart, the `servingCount` is restored alongside.  The Plan Step is also bypassed.